### PR TITLE
feat: activate for "postgres" language ID

### DIFF
--- a/src/session.ts
+++ b/src/session.ts
@@ -351,23 +351,23 @@ const createLspTraceLogger = (project?: Project): LogOutputChannel => {
  * not yet been saved to disk (untitled).
  */
 const createDocumentSelector = (project?: Project): DocumentFilter[] => {
-  if (project) {
-    return [
-      {
-        language: "sql",
+  return ["sql", "postgres"].flatMap((language) => {
+    if (project) {
+      return {
+        language,
         scheme: "file",
         pattern: Uri.joinPath(project.path, "**", "*").fsPath.replaceAll(
           "\\",
           "/"
         ),
-      },
-    ];
-  }
+      };
+    }
 
-  return ["untitled", "vscode-userdata"].map((scheme) => ({
-    language: "sql",
-    scheme,
-  }));
+    return ["untitled", "vscode-userdata"].map((scheme) => ({
+      language,
+      scheme,
+    }));
+  });
 };
 
 class PostgresToolsLanguageClient extends LanguageClient {

--- a/src/status-bar.ts
+++ b/src/status-bar.ts
@@ -47,7 +47,8 @@ export const updateStatusBar = () => {
 
 export const updateHidden = (editor: TextEditor | undefined) => {
   state.hidden =
-    editor?.document === undefined || editor.document.languageId !== "sql";
+    editor?.document === undefined ||
+    !["sql", "postgres"].includes(editor.document.languageId);
 };
 
 const getLspVersion = () => {


### PR DESCRIPTION
I have the following in my VSCode workspace settings:

```json
"files.associations": {
  "*.sql": "postgres"
},
```

But this "breaks" the postgrestools extension.

As I understand it, the [sqlfluff](https://github.com/sqlfluff/vscode-sqlfluff) extension expects the `"postgres"` language ID since I have `dialect = postgres` in my sqlfluff config.